### PR TITLE
Support fMP4 playback

### DIFF
--- a/src/abr/BufferBasedAbrManager.ts
+++ b/src/abr/BufferBasedAbrManager.ts
@@ -87,13 +87,19 @@ export class BufferBasedAbrManager implements ABRManager {
         console.log('Loading rendition:', rendition);
 
         const playlist = await fetchPlaylist(rendition.url);
-        const { segmentUrls } = await fetchPlaylistData(
+        const { segmentUrls, initSegmentUrl } = await fetchPlaylistData(
             playlist,
             rendition.url
         );
 
         await this.engine.clearBuffer();
         this.engine.requestedSegments.clear();
-        this.engine.loadSegments(segmentUrls, this.videoEl.currentTime);
+        this.engine.loadSegments(
+            {
+                initSegmentUrl,
+                segmentUrls,
+            },
+            this.videoEl.currentTime
+        );
     }
 }

--- a/src/abr/ThroughputAbrManager.ts
+++ b/src/abr/ThroughputAbrManager.ts
@@ -138,14 +138,20 @@ export class ThroughputAbrManager implements ABRManager {
         console.log(`Loading rendition: ${rendition.resolution}`);
 
         const playlist = await fetchPlaylist(rendition.url);
-        const { segmentUrls } = await fetchPlaylistData(
+        const { segmentUrls, initSegmentUrl } = await fetchPlaylistData(
             playlist,
             rendition.url
         );
 
         await this.engine.clearBuffer();
         this.engine.requestedSegments.clear();
-        this.engine.loadSegments(segmentUrls, this.videoEl.currentTime);
+        this.engine.loadSegments(
+            {
+                initSegmentUrl,
+                segmentUrls,
+            },
+            this.videoEl.currentTime
+        );
     }
 
     destroy(): void {

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -64,10 +64,8 @@ export const Player = ({
             const selectedRendition = renditions[startingIndex];
 
             const playlist = await fetchPlaylist(selectedRendition.url);
-            const { segmentUrls, totalDuration } = await fetchPlaylistData(
-                playlist,
-                selectedRendition.url
-            );
+            const { segmentUrls, totalDuration, initSegmentUrl } =
+                await fetchPlaylistData(playlist, selectedRendition.url);
 
             const codecs = selectedRendition.codecs;
 
@@ -94,7 +92,13 @@ export const Player = ({
                     networkManagerRef.current
                 );
                 setEngine(mseInstance);
-                await mseInstance.loadSegments(segmentUrls, 0);
+                await mseInstance.loadSegments(
+                    {
+                        initSegmentUrl,
+                        segmentUrls,
+                    },
+                    0
+                );
             }
 
             let abrManagerInstance: ABRManager;


### PR DESCRIPTION
This PR adds playback support for fragmented MP4. Previously, I had only supported MPEG-TS playback. 

In order to accomplish this, we needed to:
- Get the init segment off of the playlist
- Detect the format of the segments
- Append the init segment directly to the source buffer before any other segment. Don't transmux these segments
