### PR TITLE
Support audio on streams

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,7 @@ import { formatBandwidth } from './utils/format-bandwidth';
 
 export const App = () => {
     const [manifestUrl, setManifestUrl] = useState('');
-    const [abrType, setAbrType] =
-        useState<ABRManagerType>('network-throughput');
+    const [abrType, setAbrType] = useState<ABRManagerType>('buffer-based');
 
     const [debugInfo, setDebugInfo] = useState({
         currentRendition: '',

--- a/src/components/QualitySelector.tsx
+++ b/src/components/QualitySelector.tsx
@@ -1,7 +1,7 @@
 import { Renditions } from '../types/playback';
 
 type QualitySelectorProps = {
-    renditions: Renditions[];
+    renditions: Renditions;
     onSelect: (index: number) => void;
 };
 
@@ -11,7 +11,7 @@ export const QualitySelector = ({
 }: QualitySelectorProps) => {
     return (
         <div className="quality-selector">
-            {renditions.map((rendition, i) => (
+            {renditions.video.map((rendition, i) => (
                 <button key={rendition.resolution} onClick={() => onSelect(i)}>
                     {rendition.resolution}
                 </button>

--- a/src/types/abr-manager.ts
+++ b/src/types/abr-manager.ts
@@ -1,15 +1,15 @@
 import { MSEEngine } from '../playback-engine/MSEEngine';
 import { NetworkManager } from './network-manager';
-import { Renditions } from './playback';
+import { Rendition, Renditions } from './playback';
 
 export interface ABRManager {
     initialize(
         videoEl: HTMLVideoElement,
-        renditions: Renditions[],
+        renditions: Renditions,
         engine: MSEEngine,
         networkManager: NetworkManager
     ): void;
-    getRendition(): Renditions;
+    getRendition(): Rendition;
     selectRendition(): number;
     setManualRendition(index: number): void;
     clearManualRendition(): void;

--- a/src/types/playback.ts
+++ b/src/types/playback.ts
@@ -1,7 +1,13 @@
-export type Renditions = {
+export type Rendition = {
     resolution: string;
     bandwidth: number;
     url: string;
     totalDuration: number;
     codecs: string[];
+    type: 'video' | 'audio';
+};
+
+export type Renditions = {
+    video: Rendition[];
+    audio: Rendition[];
 };

--- a/src/utils/fetch-manifest.ts
+++ b/src/utils/fetch-manifest.ts
@@ -1,33 +1,65 @@
-import { Renditions } from '../types/playback';
+import { Rendition, Renditions } from '../types/playback';
 
-export const fetchManifest = async (url: string): Promise<Renditions[]> => {
+export const fetchManifest = async (url: string): Promise<Renditions> => {
     const response = await fetch(url);
     const text = await response.text();
     const lines = text.split('\n').map((line) => line.trim());
 
-    const renditions: Renditions[] = [];
+    const videoRenditions: Rendition[] = [];
+    const audioRenditions: Rendition[] = [];
 
     for (let i = 0; i < lines.length; i++) {
-        if (lines[i].startsWith('#EXT-X-STREAM-INF')) {
-            const bandwidthMatch = lines[i].match(/BANDWIDTH=(\d+)/);
-            const resolutionMatch = lines[i].match(/RESOLUTION=(\d+x\d+)/);
-            const codecsMatch = lines[i].match(/CODECS="([^"]+)"/);
+        const line = lines[i];
+
+        // Video renditions from EXT-X-STREAM-INF
+        if (line.startsWith('#EXT-X-STREAM-INF')) {
+            const bandwidth = line.match(/BANDWIDTH=(\d+)/)?.[1];
+            const resolution = line.match(/RESOLUTION=(\d+x\d+)/)?.[1];
+            const codecs = line.match(/CODECS="([^"]+)"/)?.[1];
             const relativeUrl = lines[i + 1];
 
-            if (bandwidthMatch && resolutionMatch && url) {
+            if (bandwidth && resolution && relativeUrl) {
                 const absoluteUrl = new URL(relativeUrl, url).href;
 
-                renditions.push({
-                    bandwidth: parseInt(bandwidthMatch[1], 10),
-                    resolution: resolutionMatch[1],
+                videoRenditions.push({
+                    bandwidth: parseInt(bandwidth, 10),
+                    resolution,
                     url: absoluteUrl,
                     totalDuration: 0,
-                    codecs: codecsMatch ? codecsMatch[1].split(',') : [],
+                    codecs: codecs ? codecs.split(',') : [],
+                    type: 'video',
+                });
+            }
+        }
+
+        // Audio renditions from EXT-X-MEDIA
+        if (line.startsWith('#EXT-X-MEDIA:TYPE=AUDIO')) {
+            const groupId = line.match(/GROUP-ID="([^"]+)"/)?.[1];
+            const language = line.match(/LANGUAGE="([^"]+)"/)?.[1];
+            const audioUrl = line.match(/URI="([^"]+)"/)?.[1];
+
+            if (groupId && language && audioUrl) {
+                const absoluteUrl = new URL(audioUrl, url).href;
+
+                audioRenditions.push({
+                    bandwidth: 0,
+                    resolution: `${groupId}-${language}`,
+                    url: absoluteUrl,
+                    totalDuration: 0,
+                    codecs: [],
+                    type: 'audio',
                 });
             }
         }
     }
 
-    console.log('Available renditions:', renditions);
-    return renditions;
+    console.log('Available renditions:', [
+        ...videoRenditions,
+        ...audioRenditions,
+    ]);
+
+    return {
+        video: videoRenditions,
+        audio: audioRenditions,
+    };
 };

--- a/src/utils/fetch-playlist.ts
+++ b/src/utils/fetch-playlist.ts
@@ -3,6 +3,7 @@ import { parseCodecsFromPlaylist } from './parse-codecs-from-playlist';
 const playlistCache = new Map<string, string[]>();
 
 export const fetchPlaylist = async (url: string): Promise<string[]> => {
+    console.log(`Fetching playlist from URL: ${url}`);
     if (playlistCache.has(url)) {
         console.log(`Using cached playlist for URL: ${url}`);
         return playlistCache.get(url)!;
@@ -17,6 +18,7 @@ export const fetchPlaylist = async (url: string): Promise<string[]> => {
     const playlist = text.split('\n').map((line) => line.trim());
     playlistCache.set(url, playlist);
     console.log(`Cached playlist for URL: ${url}`);
+
     return playlist;
 };
 


### PR DESCRIPTION
This PR adds support for audio streams. Previously, our player only played video.

We support audio by adding functionality to parse audio playlists from the manifest, parse segments from the audio playlist, and add those segments to a new SourceBuffer instance.

Support is limited to separate audio / video streams, for now. We'll have to add support for combined video/audio segments. I'm also not doing any adaptive switching for audio renditions. We're just grabbing the first stream, and we should add support to support multiple audio renditions, too.