### PR TITLE
Improve segment duration calculation to fix seeking issue

### DIFF
--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -200,15 +200,13 @@ export const Player = ({
 
     useEffect(() => {
         const videoEl = videoRef.current;
-        if (!videoEl || !abrManager) return;
+        if (!videoEl || !abrManager || !engine) return;
 
         const updateDebugInfo = () => {
             const currentRendition = abrManager.getRendition();
             const estimatedBandwidth =
                 networkManagerRef?.current?.getBandwidthEstimate() || 0;
-            const bufferLength = videoEl.buffered.length
-                ? videoEl.buffered.end(0) - videoEl.currentTime
-                : 0;
+            const bufferLength = engine.getBufferedLength(videoEl.currentTime);
 
             onDebugInfoUpdate({
                 currentRendition: currentRendition


### PR DESCRIPTION
This PR updates how we calculate our segment duration, which gives us an improved playback experience when seeking in the video.

We assumed our segment durations to always be 3s, but we don't control the incoming video segments that we're playing back. This led to an isssue where, when seeking ahead, we might begin requesting segments that are far too early in the video, or too late.

Example issue:
- We estimate 3s segments
- Playlist gives us 2s segments
- We seek to 9 minutes in the video
- We begin fetching segments 180, 181, etc instead of 270, 271, etc.

When this issue occurs, the media source buffered length is far behind what we're expecting. We eventually catch up, but it's a very poor experience.

I also updated the batch size from 3 to 6, so we have an increased buffer.